### PR TITLE
fix: Configure base path for GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/ReserveSystem/', // GitHub Pages用のベースパス設定
   plugins: [react()],
   optimizeDeps: {
     exclude: ['lucide-react'],


### PR DESCRIPTION
Set the `base` option in `vite.config.ts` to `/ReserveSystem/` to ensure correct asset loading on GitHub Pages. This resolves issues causing a blank page due to 404 errors when loading resources.