### PR TITLE
refactor: Configure Vite output to /docs for GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,10 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   base: '/ReserveSystem/', // GitHub Pages用のベースパス設定
   plugins: [react()],
+  build: {
+    outDir: 'docs', // ビルド出力先を 'docs' に変更
+    emptyOutDir: true, // ビルド時にdocsフォルダをクリア
+  },
   optimizeDeps: {
     exclude: ['lucide-react'],
   },


### PR DESCRIPTION
Changed `build.outDir` in `vite.config.ts` to 'docs' and enabled `emptyOutDir`. This allows deploying the build output from the `/docs` directory on the `main` branch to GitHub Pages, resolving 404 errors caused by incorrect deployment source.